### PR TITLE
Fix install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-all:
-		install
+all: install
 
 deps: FORCE
 		pip install --requirement requirements.txt


### PR DESCRIPTION
Should be
```
all: install
```
instead of
```
all:
    install
```

(install is a command on Linux)