### PR TITLE
let users use BUSCO v1.2 if they want.

### DIFF
--- a/dammit/dependencies.py
+++ b/dammit/dependencies.py
@@ -118,7 +118,7 @@ def check_blast(logger):
 
 
 def check_busco(logger):
-    busco = which('BUSCO_v1.1b1.py') or which('BUSCO_v1.2.py')
+    busco = which('BUSCO_v1.1b1.py') or which('BUSCO_v1.22.py')
     if busco is None:
         return False, 'Not found on $PATH'
     else:

--- a/dammit/dependencies.py
+++ b/dammit/dependencies.py
@@ -118,7 +118,7 @@ def check_blast(logger):
 
 
 def check_busco(logger):
-    busco = which('BUSCO_v1.1b1.py')
+    busco = which('BUSCO_v1.1b1.py') or which('BUSCO_v1.2.py')
     if busco is None:
         return False, 'Not found on $PATH'
     else:


### PR DESCRIPTION
I (and others) have upgraded to BUSCO v1.2, and this small change allows this version to be recognized by dammit.
