### PR TITLE
Environment suggestions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,8 @@ channels:
   - defaults
 dependencies:
   - python >=3.6
-  - snakemake =5.20.1
+  - snakemake-minimal =5.20.1
+  - matplotlib-base
   - mamba
   - pyyaml
   - yaml
@@ -16,6 +17,9 @@ dependencies:
   - ope >=0.8
   - khmer >=2.0
   - rich
+  - pip
+  - pip:
+    - .
   # these are for dag printing
   #- graphviz
   #- networkx

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - matplotlib-base
   - mamba
   - pyyaml
+  - curl
   - yaml
   - pandas
   - pytest


### PR DESCRIPTION
- Using `snakemake-minimal` and `matplotlib-base` to cut dependencies
- Explictilty declares `pip` and install the local version of dammit using
  ```
  - pip:
    - .
  ```
  to avoid the `pip install --no-deps .` step in the tutorial
- Added `curl` as a dependency, because some weird systems might not have `curl` installed (don't ask =])