### PR TITLE
Implement caching for Snakemake-managed conda environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,17 @@ jobs:
           environment-file: environment.yml
           auto-activate-base: false
           use-only-tar-bz2: true
+      
+      - name: cache databases
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/databases/Pfam-A.hmm
+            /home/runner/databases/Pfam-A.hmm.h3f
+            /home/runner/databases/Pfam-A.hmm.h3i
+            /home/runner/databases/Pfam-A.hmm.h3m
+            /home/runner/databases/Pfam-A.hmm.h3p
+          key: databases-${{ hashFiles('dammit/databases.yml') }}
 
       - name: setup databases
         run: |
@@ -61,4 +72,4 @@ jobs:
 
       - name: run pytest
         run: |
-          py.test -m "not long and not huge and not requires_databases"
+          py.test -s -m "not long and not huge and not requires_databases"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
       run:
         shell: bash -l {0}
     env: 
-      DAMMIT_DB_DIR: /home/runner/dammitdb
+      DAMMIT_DB_DIR: /home/runner/databases
+      DAMMIT_CONDA_DIR: /home/runner/snakemake-envs-${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -50,6 +51,13 @@ jobs:
       - name: setup databases
         run: |
           dammit run --pipeline quick databases --install
+      
+      - name: cache snakemake-conda
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/snakemake-envs-${{ matrix.os }}
+          key: ${{ matrix.os }}-snakemake-envs
 
       - name: run pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
     env: 
       DAMMIT_DB_DIR: /home/runner/databases
       DAMMIT_CONDA_DIR: /home/runner/snakemake-envs-${{ matrix.os }}
+      DAMMIT_TESTING_TEMP_BASE_DIR: /home/runner/snakemake-envs-${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Uses the `$DAMMIT_CONDA_DIR` environment variable to implement caching for conda environments managed by Snakemake rules.