### PR TITLE
Cap doit to <0.36.0 to avoid TaskLoader2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,9 @@ requirements:
     - sphinx_rtd_theme >=0.1.9
     - pytest
     - pytest-runner
-    - doit >=0.29.0
+    # After we upgrade to doit.TaskLoader2, we can remove upper pin
+    # https://github.com/dib-lab/dammit/issues/239
+    - doit >=0.29.0,<0.36.0
     - matplotlib
     - shmlast
 


### PR DESCRIPTION
I'm not familiar with conda, so this was just a guess that this was the correct file to edit.

As reported in https://github.com/dib-lab/dammit/issues/239, we are still using the old API that was removed in 0.36.0